### PR TITLE
TWEAK: Allow S3 auth without .env file credentials.

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -6,10 +6,13 @@ import {Config} from "./config";
 
 export default function newConnections(config: Config) {
     const s3 = new aws.S3();
-    s3.config.update({
-        accessKeyId: config.s3.accessKeyID,
-        secretAccessKey: config.s3.secretAccessKey
-    });
+
+    if (config.s3.accessKeyID !== '' || config.s3.secretAccessKey !== ''){
+        s3.config.update({
+            accessKeyId: config.s3.accessKeyID,
+            secretAccessKey: config.s3.secretAccessKey
+        });
+    }
 
     return {
         s3: s3,


### PR DESCRIPTION
This allows us to run from AWS resources that have roles giving us access to S3 without hard-coded creds.